### PR TITLE
GLM-6475 - Security > Add gemlock 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,47 @@
+PATH
+  remote: .
+  specs:
+    autopilot (0.1.0)
+      multi_json
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
+    coderay (1.1.3)
+    crack (0.4.5)
+      rexml
+    hashdiff (1.0.1)
+    method_source (1.0.0)
+    minitest (5.18.1)
+    minitest-around (0.5.0)
+      minitest (~> 5.0)
+    multi_json (1.15.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    public_suffix (5.0.1)
+    rake (10.5.0)
+    rexml (3.2.5)
+    vcr (6.2.0)
+    webmock (3.18.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  autopilot!
+  bundler (~> 2.1)
+  minitest (~> 5.0)
+  minitest-around
+  pry
+  rake (~> 10.0)
+  vcr
+  webmock
+
+BUNDLED WITH
+   2.1.4

--- a/autopilot.gemspec
+++ b/autopilot.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
 
   spec.add_dependency "multi_json"
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-around"


### PR DESCRIPTION
Dependabot wants us to bump Bundler and add a Gemlock file. This patch does that. Details: https://github.com/Crowd9/autopilothq-ruby/security/dependabot/5